### PR TITLE
Fix special character encoding in pinyin.js

### DIFF
--- a/app/assets/javascripts/pinyin.js
+++ b/app/assets/javascripts/pinyin.js
@@ -9,7 +9,7 @@ function myEncodeURI(s)
   for(i=0;i<s.length;i++)
   {
     if(s[i] <= '\xff')
-      out += encodeURI(s[i]);
+      out += encodeURIComponent(s[i]);
     else
       out += s[i]; // do not encode chinese characters 
   }
@@ -31,7 +31,7 @@ function updatePinyin()
     $('#pinyin').text("");
     $('#english').text("");
   }
-  $.getJSON("/pinyin/convert/?c="+encodeURI(new_val), updatePinyinSuccess);
+  $.getJSON("/pinyin/convert/?c="+encodeURIComponent(new_val), updatePinyinSuccess);
   last_val = new_val;
 }
 
@@ -180,7 +180,7 @@ function buttonClick()
 
 function hashChange()
 {
-  $('#input').val(decodeURI(window.location.hash.substr(1)));
+  $('#input').val(decodeURIComponent(window.location.hash.substr(1)));
   if(conversion != null && conversion.q == $('#input').val())
   {
     showConversion();    


### PR DESCRIPTION
EncodeURI does not encode special characters: "; , / ? : @ & = + $",
which meant that various combinations of these - particularly the ampersand,
could prevent or truncate conversions.

This patch replaces EncodeURI with EncodeURIComponent, which is the same
except that it converts those special characters too.

This works for the context in which it is used - the part of the URL
following the hash.

fixes #17
