### PR TITLE
Fix link to ruby-install in installation.md

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -87,9 +87,9 @@ source /usr/local/share/chruby/auto.sh
 To install the right version of ruby, try
 [ruby-installer](https://github.com/postmodern/ruby-install)):
 ```
-wget -O ruby-install-0.6.0.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.0.tar.gz
-tar -xzvf ruby-install-0.6.0.tar.gz
-cd ruby-install-0.6.0/
+wget -O ruby-install-0.6.1.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.1.tar.gz
+tar -xzvf ruby-install-0.6.1.tar.gz
+cd ruby-install-0.6.1/
 sudo make install
 ```
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -85,7 +85,7 @@ source /usr/local/share/chruby/auto.sh
 ```
 
 To install the right version of ruby, try
-[ruby-installer](https://github.com/postmodern/ruby-instal)):
+[ruby-installer](https://github.com/postmodern/ruby-install)):
 ```
 wget -O ruby-install-0.6.0.tar.gz https://github.com/postmodern/ruby-install/archive/v0.6.0.tar.gz
 tar -xzvf ruby-install-0.6.0.tar.gz


### PR DESCRIPTION
It was missing an 'l'.